### PR TITLE
Refresh credentials should first check...

### DIFF
--- a/lib/ex_aws_credential_process/cmd.ex
+++ b/lib/ex_aws_credential_process/cmd.ex
@@ -1,61 +1,13 @@
 defmodule ExAwsCredentialProcess.Cmd do
   @moduledoc """
-  Supports updating :ex_aws AWS credentials using a credential_process command
+  Behaviour for supporting updating :ex_aws AWS credentials using a credential_process command
   """
 
-  require Logger
+  @callback fetch_new_credentials(map) ::
+              {:ok, list(), DateTime.t()}
+              | {:error, :credential_process_error, :invalid_json, String.t()}
+              | {:error, :credential_process_error, :invalid_credentials_map, String.t()}
+              | {:error, :credential_process_error, :invalid_expiration, String.t()}
 
-  @doc """
-  Fetches new AWS credentials using the given credential_process command and,
-  if sucessful, updates the global :ex_aws configuration accordingly
-  """
-  def fetch_new_credentials(credential_process_cmd) do
-    with {:ok, raw_result} <- run(credential_process_cmd) do
-      parse(raw_result)
-    end
-  end
-
-  defp run(credential_process_cmd) do
-    case Porcelain.shell(credential_process_cmd, err: :string) do
-      %Porcelain.Result{status: 0, out: out} ->
-        # This result must conform to the specification here:
-        # https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#sourcing-credentials-from-external-processes
-        {:ok, out}
-
-      %Porcelain.Result{status: status, err: err, out: out} ->
-        {:error,
-         {:credential_process_error, :non_zero_exit_status, %{status: status, err: err, out: out}}}
-    end
-  end
-
-  defp parse(raw_result) do
-    json_codec = Application.fetch_env!(:ex_aws_credential_process, :json_codec)
-
-    with {:decode, {:ok, m}} when is_map(m) <- {:decode, json_codec.decode(raw_result)},
-         {:valid_map,
-          %{
-            "AccessKeyId" => access_key_id,
-            "SecretAccessKey" => secret_access_key,
-            "SessionToken" => session_token,
-            "Expiration" => expiration
-          }} <- {:valid_map, m},
-         {:valid_expiration, {:ok, expiration, 0}} <-
-           {:valid_expiration, DateTime.from_iso8601(expiration)} do
-      {:ok,
-       [
-         access_key_id: access_key_id,
-         secret_access_key: secret_access_key,
-         security_token: session_token
-       ], expiration}
-    else
-      {:decode, _} ->
-        {:error, {:credential_process_error, :invalid_json, raw_result}}
-
-      {:valid_map, _} ->
-        {:error, {:credential_process_error, :invalid_credentials_map, raw_result}}
-
-      {:valid_expiration, _} ->
-        {:error, {:credential_process_error, :invalid_expiration, raw_result}}
-    end
-  end
+  defdelegate fetch_new_credentials(params), to: ExAwsCredentialProcess.Cmd.Impl
 end

--- a/lib/ex_aws_credential_process/cmd/impl.ex
+++ b/lib/ex_aws_credential_process/cmd/impl.ex
@@ -1,0 +1,63 @@
+defmodule ExAwsCredentialProcess.Cmd.Impl do
+  @moduledoc """
+  Supports updating :ex_aws AWS credentials using a credential_process command
+  """
+
+  @behaviour ExAwsCredentialProcess.Cmd
+
+  require Logger
+
+  @doc """
+  Fetches new AWS credentials using the given credential_process command and,
+  if sucessful, updates the global :ex_aws configuration accordingly
+  """
+  def fetch_new_credentials(credential_process_cmd) do
+    with {:ok, raw_result} <- run(credential_process_cmd) do
+      parse(raw_result)
+    end
+  end
+
+  defp run(credential_process_cmd) do
+    case Porcelain.shell(credential_process_cmd, err: :string) do
+      %Porcelain.Result{status: 0, out: out} ->
+        # This result must conform to the specification here:
+        # https://docs.aws.amazon.com/cli/latest/topic/config-vars.html#sourcing-credentials-from-external-processes
+        {:ok, out}
+
+      %Porcelain.Result{status: status, err: err, out: out} ->
+        {:error,
+         {:credential_process_error, :non_zero_exit_status, %{status: status, err: err, out: out}}}
+    end
+  end
+
+  defp parse(raw_result) do
+    json_codec = Application.fetch_env!(:ex_aws_credential_process, :json_codec)
+
+    with {:decode, {:ok, m}} when is_map(m) <- {:decode, json_codec.decode(raw_result)},
+         {:valid_map,
+          %{
+            "AccessKeyId" => access_key_id,
+            "SecretAccessKey" => secret_access_key,
+            "SessionToken" => session_token,
+            "Expiration" => expiration
+          }} <- {:valid_map, m},
+         {:valid_expiration, {:ok, expiration, 0}} <-
+           {:valid_expiration, DateTime.from_iso8601(expiration)} do
+      {:ok,
+       [
+         access_key_id: access_key_id,
+         secret_access_key: secret_access_key,
+         security_token: session_token
+       ], expiration}
+    else
+      {:decode, _} ->
+        {:error, {:credential_process_error, :invalid_json, raw_result}}
+
+      {:valid_map, _} ->
+        {:error, {:credential_process_error, :invalid_credentials_map, raw_result}}
+
+      {:valid_expiration, _} ->
+        {:error, {:credential_process_error, :invalid_expiration, raw_result}}
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,9 +4,10 @@ defmodule ExAwsCredentialProcess.MixProject do
   def project do
     [
       app: :ex_aws_credential_process,
-      version: "1.0.0",
+      version: "1.0.1",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
+      elixirc_paths: elixirc_paths(Mix.env()),
       deps: deps(),
       package: package(),
       docs: [
@@ -24,12 +25,16 @@ defmodule ExAwsCredentialProcess.MixProject do
     ]
   end
 
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
+
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
       {:ex_aws, "~> 2.0"},
       {:ex_doc, "~> 0.16", only: [:dev, :test]},
       {:jason, ">= 1.1.2", only: [:dev, :test]},
+      {:mox, "~> 0.5", only: :test},
       {:porcelain, "~> 2.0"}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -5,6 +5,7 @@
   "jason": {:hex, :jason, "1.1.2", "b03dedea67a99223a2eaf9f1264ce37154564de899fd3d8b9a21b1a6fd64afe7", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "fdf843bca858203ae1de16da2ee206f53416bbda5dc8c9e78f43243de4bc3afe"},
   "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "a10c6eb62cca416019663129699769f0c2ccf39428b3bb3c0cb38c718a0c186d"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "d4b316c7222a85bbaa2fd7c6e90e37e953257ad196dc229505137c5e505e9eff"},
+  "mox": {:hex, :mox, "0.5.2", "55a0a5ba9ccc671518d068c8dddd20eeb436909ea79d1799e2209df7eaa98b6c", [:mix], [], "hexpm", "df4310628cd628ee181df93f50ddfd07be3e5ecc30232d3b6aadf30bdfe6092b"},
   "nimble_parsec": {:hex, :nimble_parsec, "0.5.2", "1d71150d5293d703a9c38d4329da57d3935faed2031d64bc19e77b654ef2d177", [:mix], [], "hexpm", "51aa192e0941313c394956718bdb1e59325874f88f45871cff90345b97f60bba"},
   "porcelain": {:hex, :porcelain, "2.0.3", "2d77b17d1f21fed875b8c5ecba72a01533db2013bd2e5e62c6d286c029150fdc", [:mix], [], "hexpm", "dc996ab8fadbc09912c787c7ab8673065e50ea1a6245177b0c24569013d23620"},
 }

--- a/test/ex_aws_credential_process_test.exs
+++ b/test/ex_aws_credential_process_test.exs
@@ -1,4 +1,85 @@
 defmodule ExAwsCredentialProcessTest do
   use ExUnit.Case
   doctest ExAwsCredentialProcess
+
+  import Mox
+
+  @table_name :ex_aws_credential_process_cache
+
+  setup :set_mox_from_context
+  setup :verify_on_exit!
+
+  setup do
+    state = %{
+      credential_process_cmd: "fake",
+      refresh_strategy: ExAwsCredentialProcess.Refresh.AfterExpired
+    }
+
+    initial_credentials = [
+      access_key_id: "1234AKI",
+      secret_access_key: "1234SAK",
+      security_token: "1234ST"
+    ]
+
+    {:ok, _pid} = ExAwsCredentialProcess.start_link(state)
+    %{initial_credentials: initial_credentials}
+  end
+
+  test "a second refresh credentials request within expiration time will not fetch new credentials",
+       %{initial_credentials: initial_credentials} do
+    expiration = DateTime.add(DateTime.utc_now(), 3600, :second)
+
+    MockExAwsCredentialProcess.Cmd
+    |> expect(:fetch_new_credentials, fn _ -> {:ok, initial_credentials, expiration} end)
+
+    assert GenServer.call(ExAwsCredentialProcess, :refresh_credentials) ==
+             {:ok, initial_credentials}
+
+    assert GenServer.call(ExAwsCredentialProcess, :refresh_credentials) ==
+             {:ok, initial_credentials}
+  end
+
+  test "a second refresh credentials request after expiration time will fetch new credentials", %{
+    initial_credentials: initial_credentials
+  } do
+    expiration = DateTime.add(DateTime.utc_now(), 1, :microsecond)
+    new_expiration = DateTime.add(DateTime.utc_now(), 3600, :second)
+
+    new_credentials = [
+      access_key_id: "234AKI",
+      secret_access_key: "234SAK",
+      security_token: "234ST"
+    ]
+
+    MockExAwsCredentialProcess.Cmd
+    |> expect(:fetch_new_credentials, fn _ -> {:ok, initial_credentials, expiration} end)
+    |> expect(:fetch_new_credentials, fn _ ->
+      {:ok, new_credentials, new_expiration}
+    end)
+
+    assert GenServer.call(ExAwsCredentialProcess, :refresh_credentials) ==
+             {:ok, initial_credentials}
+
+    assert GenServer.call(ExAwsCredentialProcess, :refresh_credentials) ==
+             {:ok, new_credentials}
+  end
+
+  test "if there are no credential entries in the cache, a refresh credentials request fetches credentials and caches them",
+       %{
+         initial_credentials: initial_credentials
+       } do
+    expiration = DateTime.add(DateTime.utc_now(), 1, :microsecond)
+
+    MockExAwsCredentialProcess.Cmd
+    |> expect(:fetch_new_credentials, fn _ -> {:ok, initial_credentials, expiration} end)
+
+    assert GenServer.call(ExAwsCredentialProcess, :refresh_credentials) ==
+             {:ok, initial_credentials}
+
+    assert :ets.lookup(@table_name, :credentials) == [
+             {:credentials,
+              [access_key_id: "1234AKI", secret_access_key: "1234SAK", security_token: "1234ST"],
+              expiration, ExAwsCredentialProcess.Refresh.AfterExpired}
+           ]
+  end
 end

--- a/test/support/mocks.ex
+++ b/test/support/mocks.ex
@@ -1,0 +1,1 @@
+Mox.defmock(MockExAwsCredentialProcess.Cmd, for: ExAwsCredentialProcess.Cmd)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,7 @@
 ExUnit.start()
+
+Application.put_env(
+  :ex_aws_credential_process,
+  :credential_process,
+  MockExAwsCredentialProcess.Cmd
+)


### PR DESCRIPTION
- Refresh credentials should first check to see if a process has
  already written to the ets cache before making a network request
- Add some tests with Mox

Notes: @nathanl - based on my understanding of discussion today; also added some Mox tests